### PR TITLE
Fix header references to consider header blocking and enable smooth scrolling for supported browsers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@
   </div><!-- /.container-fluid -->
 </nav>
     <!-- Hero unit -->
-    <div class="hero" id="top">
+    <div class="hero">
+        <span id="top"></span>
         <div class="hero__overlay hero__overlay--gradient"></div>
         <div class="hero__mask"></div>
         <div class="hero__inner">
@@ -82,7 +83,8 @@
         </span>
     </div>
 <div class="body container">
-    <div class="container section" id="about">
+    <div class="container section">
+        <span id="about"></span>
         <div class="row center">
             <h2 class="section-heading"  style="margin:auto; text-align: center; padding-top: 30px;">What is Hackcouver?</h2>
             <hr class="divider" style="margin-bottom: 30px;">
@@ -114,7 +116,8 @@
             </div>
         </div>
     </div>
-<div class="faq section" id="faq">
+<div class="faq section">
+    <span id="faq"></span>
     <h2 class="section-heading"  style="margin:auto; text-align: center; padding-top: 30px;">Frequently Asked Questions</h2>
     <hr class="divider" style="margin-bottom: 30px;">
 
@@ -152,7 +155,8 @@
 </div>
 </div>
     <!-- Call To Action -->
-    <div class="cta cta--reverse" id="contact">
+    <div class="cta cta--reverse">
+        <span id="contact"></span>
         <div class="container">
             <div class="cta__inner">
                 <h2 class="cta__title">Questions? Want to sponsor? Get in touch!</h2>

--- a/styles/style.css
+++ b/styles/style.css
@@ -26,6 +26,15 @@ body {
   margin: 0;
   font-family: Raleway;}
 
+div {
+  position: relative;
+}
+
+div span {
+  position: absolute;
+  top: -50px;
+}
+
 /**
  * Correct the font size and margin on `h1` elements within `section` and
  * `article` contexts in Chrome, Firefox, and Safari.

--- a/styles/style.css
+++ b/styles/style.css
@@ -11,7 +11,11 @@ html {
   line-height: 1.15;
   /* 1 */
   -webkit-text-size-adjust: 100%;
-  /* 2 */ }
+  /* 2 */
+
+  /* currently only supported in Chrome 61+ and Firefox 36+ */
+  scroll-behavior: smooth;
+}
 
 /* Sections
    ========================================================================== */


### PR DESCRIPTION
The way the references jump has the heading blocked by the header and is quite ugly. Fixed it by shifting the ref location 50px up above the actual heading. Also, added smooth scrolling for supported browsers (only Chrome 61+ and Firefox 36+ at this point because I'm too lazy to deal with jQuery :P).