### PR TITLE
Prevent navbar going crazy when clicked without menu.

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,27 @@
                     <span class="sr-only">Toggle navigation</span>
 
                     <span class="glyphicon glyphicon-menu-hamburger" aria-hidden="true"></span>
+
+                    <script>
+                        const toggleButton = document.getElementById("closes-navbar");
+                        const toggleThreshold = 750;
+
+                        $(window).ready(function() {
+                            if ($(window).width() <= toggleThreshold) {
+                                toggleButton.setAttribute("data-toggle", "collapse");
+                            } else {
+                                toggleButton.removeAttribute("data-toggle");
+                            }
+                        });
+
+                        $(window).resize(function() {
+                            if ($(window).width() <= toggleThreshold) {
+                                toggleButton.setAttribute("data-toggle", "collapse");
+                            } else {
+                                toggleButton.removeAttribute("data-toggle");
+                            }
+                        });
+                    </script>
                 </button>
                 <a href="/"><img src="images/logo.png" height="50"></a>
             </div>


### PR DESCRIPTION
Clicking navbar buttons tries to expand/collapse the menu even when it's not there (width >750). This limits it to only toggle when dropdown menu exists.

I'm not a web developer so I don't know whether a script this size warrants an individual source file so you can modify the changes as you wish.